### PR TITLE
Restrict package build inputs to src

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,8 +1,13 @@
 {
-    "extends": "./tsconfig.json",
-    "exclude": [
-        "src/**/*.test.ts",
-        "src/**/*.test.tsx",
-        "stories",
-    ]
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ]
 }


### PR DESCRIPTION
**Summary**
- Limit the build config to files under `src/**/*`.
- Set `rootDir` to `./src` so emitted `dist` paths mirror package source structure.
- Keep source test files excluded from the production build.

**Testing**
- Not run (not requested)